### PR TITLE
docs: fix response typo

### DIFF
--- a/docs/01-llm-intro/reasoning.md
+++ b/docs/01-llm-intro/reasoning.md
@@ -84,7 +84,7 @@ best_of_n.generate(query_tensors, device=device)
 
 ![alt text](./imgs/google-star.png)
 
-> Query -> repsonse (false) -> response -> cot
+> Query -> response (false) -> response -> cot
 
 #### 1. 推理的重要性：
   - 文档首先强调了推理在人类决策中的重要性，并指出在数学、常识问答等复杂任务中，显式生成推理步骤（即“理由”）可以显著提高语言模型的表现。


### PR DESCRIPTION
## Problem
The reasoning notes include a small typo in the STaR flow: `repsonse`.

## Solution
Correct it to `response`.

## Validation
- `git diff --check`

Confidence score: 80/100
Category: docs/typo